### PR TITLE
feat: Allow 'startingBlock' to be a negative offset

### DIFF
--- a/src/config/config.schema.ts
+++ b/src/config/config.schema.ts
@@ -12,6 +12,11 @@ const POSITIVE_NUMBER_SCHEMA = {
     type: "number",
     minimum: 0,
 }
+const INTEGER_SCHEMA = {
+    $id: "integer-schema",
+    type: "number",
+    multipleOf: 1,
+}
 const POSITIVE_NON_ZERO_INTEGER_SCHEMA = {
     $id: "positive-non-zero-integer-schema",
     type: "number",
@@ -115,7 +120,7 @@ const LISTENER_SCHEMA = {
             minimum: 0,
             maximum: 1_000_000,
         },
-        startingBlock: { $ref: "positive-number-schema" },
+        startingBlock: { $ref: "integer-schema" },
     },
     additionalProperties: false
 }
@@ -322,6 +327,7 @@ const ENDPOINTS_SCHEMA = {
 export function getConfigValidator(): AnyValidateFunction<unknown> {
     const ajv = new Ajv({ strict: true });
     ajv.addSchema(POSITIVE_NUMBER_SCHEMA);
+    ajv.addSchema(INTEGER_SCHEMA);
     ajv.addSchema(POSITIVE_NON_ZERO_INTEGER_SCHEMA);
     ajv.addSchema(NON_EMPTY_STRING_SCHEMA);
     ajv.addSchema(ADDRESS_FIELD_SCHEMA);

--- a/src/listener/listener.worker.ts
+++ b/src/listener/listener.worker.ts
@@ -227,9 +227,18 @@ class ListenerWorker {
             // Do not initialize 'fromBlock' whilst 'currentStatus' is null, even if
             // 'startingBlock' is specified.
             if (this.currentStatus != null) {
-                fromBlock = (
-                    this.config.startingBlock ?? this.currentStatus.blockNumber
-                );
+                if (this.config.startingBlock != null) {
+                    if (this.config.startingBlock < 0) {
+                        fromBlock = this.currentStatus.blockNumber + this.config.startingBlock;
+                        if (fromBlock < 0) {
+                            throw new Error(`Invalid 'startingBlock': negative offset is larger than the current block number.`)
+                        }
+                    } else {
+                        fromBlock = this.config.startingBlock;
+                    }
+                } else {
+                    fromBlock = this.currentStatus.blockNumber;
+                }
             }
 
             await wait(this.config.processingInterval);


### PR DESCRIPTION
Allow the `startingBlock` configuration to be a negative offset. This is useful to make the Underwriter always recover the last n blocks upon starting.